### PR TITLE
Simpler read api

### DIFF
--- a/src/main/java/com/evilco/mc/nbt/tag/IAnonymousTagContainer.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/IAnonymousTagContainer.java
@@ -20,6 +20,14 @@ public interface IAnonymousTagContainer extends ITagContainer {
 	 * @return
 	 */
 	public List<ITag> getTags ();
+	
+	/**
+	 * Gets all tags in this container, ensuring their type is as expected
+	 * @param tagClass the expected tag type of the contents
+	 * @return the tags in this container
+	 * @throws UnexpectedTagTypeException at least one tag in this container is not of the expected type
+	 */
+	public <T extends ITag> List<T> getTags(Class<T> tagClass) throws UnexpectedTagTypeException;
 
 	/**
 	 * Sets a tag.

--- a/src/main/java/com/evilco/mc/nbt/tag/INamedTagContainer.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/INamedTagContainer.java
@@ -14,6 +14,17 @@ public interface INamedTagContainer extends ITagContainer {
 	 * @param name The tag name.
 	 */
 	public ITag getTag (@Nonnull String name);
+	
+	/**
+	 * Returns the tag associated with the given name, ensuring its type is as expected
+	 * @param name The tag name
+	 * @param tagClass The expected tag type
+	 * @return the tag
+	 * @throws UnexpectedTagTypeException The tag is found, but of different type than expected
+	 * @throws TagNotFoundException There is no tag with the given name in this container
+	 */
+	public <T extends ITag> T getTag(String name, Class<T> tagClass) 
+			throws UnexpectedTagTypeException, TagNotFoundException;
 
 	/**
 	 * Returns a named map of all tags.

--- a/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
@@ -3,11 +3,13 @@ package com.evilco.mc.nbt.tag;
 import com.evilco.mc.nbt.stream.NbtInputStream;
 import com.evilco.mc.nbt.stream.NbtOutputStream;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -90,6 +92,81 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 					+ ", but is of type " + tag.getClass().getSimpleName());
 
 		return (T) tag;
+	}
+	
+	public TagCompound getCompound(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagCompound.class);
+	}
+	
+	public int getInteger(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagInteger.class).getValue();
+	}
+	
+	public short getShort(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagShort.class).getValue();
+	}
+	
+	public byte getByte(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagByte.class).getValue();
+	}
+	
+	public long getLong(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagLong.class).getValue();
+	}
+	
+	public double getDouble(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagDouble.class).getValue();
+	}
+	
+	public float getFloat(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagFloat.class).getValue();
+	}
+	
+	public String getString(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagString.class).getValue();
+	}
+	
+	public <T extends ITag> List<T> getList(String name, Class<T> itemClass)
+			throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagList.class).getTags(itemClass);
+	}
+	
+	public int[] getIntegerArray(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagIntegerArray.class).getValues();
+	}
+	
+	public byte[] getByteArray(String name) throws UnexpectedTagTypeException, TagNotFoundException {
+		return getTag(name, TagByteArray.class).getValue();
+	}
+	
+	public String[] getStringArray(String name)
+			throws UnexpectedTagTypeException, TagNotFoundException {
+		List<TagString> tags = getList(name, TagString.class);
+		String[] array = new String[tags.size()];
+		for (int i = 0; i < tags.size(); i++) {
+			array[i] = tags.get(i).getValue();
+		}
+		return array;
+	}
+	
+	public double[] getDoubleArray(String name)
+			throws UnexpectedTagTypeException, TagNotFoundException {
+		List<TagDouble> tags = getList(name, TagDouble.class);
+		double[] array = new double[tags.size()];
+		for (int i = 0; i < tags.size(); i++) {
+			array[i] = tags.get(i).getValue();
+		}
+		return array;
+	}
+	
+	public float[] getFloatArray(String name)
+			throws UnexpectedTagTypeException, TagNotFoundException {
+		List<TagFloat> tags = getList(name, TagFloat.class);
+		float[] array = new float[tags.size()];
+		for (int i = 0; i < tags.size(); i++) {
+			array[i] = tags.get(i).getValue();
+		}
+		return array;
 	}
 
 	/**

--- a/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
@@ -76,6 +76,25 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 	/**
 	 * {@inheritDoc}
 	 */
+	@SuppressWarnings("unchecked")
+	public <T extends ITag> T getTag(String name, Class<T> tagClass)
+			throws UnexpectedTagTypeException, TagNotFoundException {
+		ITag tag = getTag(name);
+
+		if (tag == null)
+			throw new TagNotFoundException(
+					"The compound tag is missing a " + name + " entry");
+		if (!tagClass.isInstance(tag))
+			throw new UnexpectedTagTypeException("The compound entry " + name
+					+ " should be of type " + tagClass.getSimpleName()
+					+ ", but is of type " + tag.getClass().getSimpleName());
+
+		return (T) tag;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public Map<String, ITag> getTags () {
 		return (new ImmutableMap.Builder<String, ITag> ().putAll (this.tags)).build ();

--- a/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
@@ -3,7 +3,6 @@ package com.evilco.mc.nbt.tag;
 import com.evilco.mc.nbt.stream.NbtInputStream;
 import com.evilco.mc.nbt.stream.NbtOutputStream;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
@@ -94,51 +93,138 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 		return (T) tag;
 	}
 	
+	/**
+	 * Gets the tag of the given name and verifies that it is a compound tag
+	 * @param name the tag's name
+	 * @return the compound tag
+	 * @throws UnexpectedTagTypeException the tag exists, but is not a compound tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public TagCompound getCompound(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagCompound.class);
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an integer tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an integer tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public int getInteger(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagInteger.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an short tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an short tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public short getShort(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagShort.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an byte tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an byte tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public byte getByte(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagByte.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an long tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an long tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public long getLong(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagLong.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an double tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an double tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public double getDouble(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagDouble.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an float tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an float tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public float getFloat(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagFloat.class).getValue();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an string tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an string tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public String getString(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagString.class).getValue();
 	}
 	
+	/**
+	 * Gets the contents of the list tag and checks its item types
+	 * @param name the tag's name
+	 * @param itemClass the type the list items are expected to be of
+	 * @return the contents of the list tag
+	 * @throws UnexpectedTagTypeException the tag exists, but is not a list tag - or - 
+	 *   the contents of the list tag are not of the expected type
+	 * @throws TagNotFoundException the list tag does not exist
+	 */
 	public <T extends ITag> List<T> getList(String name, Class<T> itemClass)
 			throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagList.class).getTags(itemClass);
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an integer array tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an integer array tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public int[] getIntegerArray(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagIntegerArray.class).getValues();
 	}
-	
+
+	/**
+	 * Verifies that the tag of the given name is an byte array tag and gets its value
+	 * @param name the tag's name
+	 * @return the tag's value
+	 * @throws UnexpectedTagTypeException the tag exists, but is not an byte array tag
+	 * @throws TagNotFoundException the tag does not exist
+	 */
 	public byte[] getByteArray(String name) throws UnexpectedTagTypeException, TagNotFoundException {
 		return getTag(name, TagByteArray.class).getValue();
 	}
-	
+
+	/**
+	 * Gets the contents of the list tag and verifies that its items are string tags
+	 * @param name the tag's name
+	 * @return the values of the list tag's item tags
+	 * @throws UnexpectedTagTypeException the tag exists, but is not a list tag - or - 
+	 *   the contents of the list tag are not string tags
+	 * @throws TagNotFoundException the list tag does not exist
+	 */
 	public String[] getStringArray(String name)
 			throws UnexpectedTagTypeException, TagNotFoundException {
 		List<TagString> tags = getList(name, TagString.class);
@@ -148,7 +234,15 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 		}
 		return array;
 	}
-	
+
+	/**
+	 * Gets the contents of the list tag and verifies that its items are double tags
+	 * @param name the tag's name
+	 * @return the values of the list tag's item tags
+	 * @throws UnexpectedTagTypeException the tag exists, but is not a list tag - or - 
+	 *   the contents of the list tag are not double tags
+	 * @throws TagNotFoundException the list tag does not exist
+	 */
 	public double[] getDoubleArray(String name)
 			throws UnexpectedTagTypeException, TagNotFoundException {
 		List<TagDouble> tags = getList(name, TagDouble.class);
@@ -158,7 +252,15 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 		}
 		return array;
 	}
-	
+
+	/**
+	 * Gets the contents of the list tag and verifies that its items are float tags
+	 * @param name the tag's name
+	 * @return the values of the list tag's item tags
+	 * @throws UnexpectedTagTypeException the tag exists, but is not a list tag - or - 
+	 *   the contents of the list tag are not float tags
+	 * @throws TagNotFoundException the list tag does not exist
+	 */
 	public float[] getFloatArray(String name)
 			throws UnexpectedTagTypeException, TagNotFoundException {
 		List<TagFloat> tags = getList(name, TagFloat.class);

--- a/src/main/java/com/evilco/mc/nbt/tag/TagList.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagList.java
@@ -93,6 +93,24 @@ public class TagList extends AbstractTag implements IAnonymousTagContainer {
 	/**
 	 * {@inheritDoc}
 	 */
+	@SuppressWarnings("unchecked")
+	public <T extends ITag> List<T> getTags(Class<T> tagClass) throws UnexpectedTagTypeException {
+		ImmutableList.Builder<T> builder = new ImmutableList.Builder<T>();
+		for (ITag tag : tagList) {
+			if (!tagClass.isInstance(tag))
+				throw new UnexpectedTagTypeException(
+						"The list entry should be of type "
+								+ tagClass.getSimpleName()
+								+ ", but is of type "
+								+ tag.getClass().getSimpleName());
+			builder.add((T) tag);
+		}
+		return builder.build();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public byte getTagID () {
 		return TagType.LIST.typeID;

--- a/src/main/java/com/evilco/mc/nbt/tag/TagNotFoundException.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagNotFoundException.java
@@ -1,0 +1,23 @@
+package com.evilco.mc.nbt.tag;
+
+import java.io.IOException;
+
+/**
+ * An exception that is thrown when trying to access a component of a CompoundTag that does not exist
+ */
+public class TagNotFoundException extends IOException {
+	public TagNotFoundException() {
+	}
+
+	public TagNotFoundException(String message) {
+		super(message);
+	}
+
+	public TagNotFoundException(Throwable cause) {
+		super(cause);
+	}
+
+	public TagNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/evilco/mc/nbt/tag/TagNotFoundException.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagNotFoundException.java
@@ -6,17 +6,36 @@ import java.io.IOException;
  * An exception that is thrown when trying to access a component of a CompoundTag that does not exist
  */
 public class TagNotFoundException extends IOException {
+	private static final long serialVersionUID = -4631008535746749103L;
+
+	/**
+	 * Constructs a TagNotFoundException with a default message
+	 */
 	public TagNotFoundException() {
+		super("The tag does not exist");
 	}
 
+	/**
+	 * Constructs a TagNotFoundException with the given message
+	 * @param message the exception message
+	 */
 	public TagNotFoundException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs a TagNotFoundException with a cause
+	 * @param cause the cause exception
+	 */
 	public TagNotFoundException(Throwable cause) {
 		super(cause);
 	}
 
+	/**
+	 * Constructs a TagNotFoundException with the given message and a cause
+	 * @param message the exception message
+	 * @param cause the cause exception
+	 */
 	public TagNotFoundException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/src/main/java/com/evilco/mc/nbt/tag/UnexpectedTagTypeException.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/UnexpectedTagTypeException.java
@@ -1,0 +1,24 @@
+package com.evilco.mc.nbt.tag;
+
+import java.io.IOException;
+
+/**
+ * An exception that is thrown when an entry of a TagCompound or TagList
+ * is not of the expected tag type
+ */
+public class UnexpectedTagTypeException extends IOException {
+	public UnexpectedTagTypeException() {
+	}
+
+	public UnexpectedTagTypeException(String message) {
+		super(message);
+	}
+
+	public UnexpectedTagTypeException(Throwable cause) {
+		super(cause);
+	}
+
+	public UnexpectedTagTypeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/evilco/mc/nbt/tag/UnexpectedTagTypeException.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/UnexpectedTagTypeException.java
@@ -7,17 +7,36 @@ import java.io.IOException;
  * is not of the expected tag type
  */
 public class UnexpectedTagTypeException extends IOException {
+	private static final long serialVersionUID = -6604963428978583800L;
+
+	/**
+	 * Constructs an UnexpectedTagTypeException with a default message
+	 */
 	public UnexpectedTagTypeException() {
+		super("The tag is not of the expected type");
 	}
 
+	/**
+	 * Constructs an UnexpectedTagTypeException with the given message
+	 * @param message the exception message
+	 */
 	public UnexpectedTagTypeException(String message) {
 		super(message);
 	}
 
+	/**
+	 * Constructs an UnexpectedTagTypeException with a cause
+	 * @param cause the cause exception
+	 */
 	public UnexpectedTagTypeException(Throwable cause) {
 		super(cause);
 	}
 
+	/**
+	 * Constructs an UnexpectedTagTypeException with the given message and a cause
+	 * @param message the exception message
+	 * @param cause the cause exception
+	 */
 	public UnexpectedTagTypeException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/src/test/java/ReadWriteTest.java
+++ b/src/test/java/ReadWriteTest.java
@@ -59,9 +59,22 @@ public class ReadWriteTest {
 		NbtInputStream nbtInputStream = new NbtInputStream (inputStream);
 
 		// read data
-		ITag tag = nbtInputStream.readTag ();
+		TagCompound tag = (TagCompound)nbtInputStream.readTag ();
 
 		// verify output
 		Assert.assertNotNull (tag);
+		
+		Assert.assertEquals(4.2d, tag.getDouble("doubleTag"), 0.1);
+		Assert.assertEquals(4.2f, tag.getFloat("floatTag"), 0.1);
+		Assert.assertEquals(42, tag.getInteger("integerTag"));
+		Assert.assertEquals(42, tag.getLong("longTag"));
+		Assert.assertEquals(42, tag.getShort("shortTag"));
+		Assert.assertEquals("Bananrama", tag.getString("stringTag"));
+		Assert.assertArrayEquals(new byte[] { 0, 1, 2, 3 }, tag.getByteArray("byteArrayTag"));
+		Assert.assertArrayEquals(new int[] { 21, 42, 84 }, tag.getIntegerArray("integerArrayTag"));
+		Assert.assertArrayEquals(new String[] { "Hello", "World!" }, tag.getStringArray("listTag"));
+		TagCompound inner = tag.getCompound("compoundTag");
+		Assert.assertEquals("Bananrama", inner.getString("name"));
+		
 	}
 }


### PR DESCRIPTION
I added some methods for easier traversal of a NBT tree. Its focus lies on reading compound and list structures with primitive values.

An excerpt of the new ReadWriteTest to see how it works:

```
TagCompound tag = (TagCompound)nbtInputStream.readTag();
Assert.assertEquals(4.2d, tag.getDouble("doubleTag"), 0.1);
Assert.assertArrayEquals(new int[] { 21, 42, 84 }, tag.getIntegerArray("integerArrayTag"));
Assert.assertArrayEquals(new String[] { "Hello", "World!" }, tag.getStringArray("listTag"));
TagCompound inner = tag.getCompound("compoundTag");
Assert.assertEquals("Bananrama", inner.getString("name"));
```
