### PR TITLE
Remove using diamond operator for JDK 6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,14 +90,14 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>16.0.1</version>
+			<version>18.0</version>
 		</dependency>
 
 		<!-- Java Annotations -->
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
-			<version>2.0.3</version>
+			<version>3.0.0</version>
 		</dependency>
 
 		<!-- junit -->
@@ -172,8 +172,8 @@
 				<version>3.1</version>
 
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 
@@ -181,7 +181,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.5</version>
 
 				<configuration>
 					<archive>

--- a/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagCompound.java
@@ -31,7 +31,7 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 	public TagCompound (String name) {
 		super (name);
 
-		this.tags = new HashMap<> ();
+		this.tags = new HashMap<String, ITag> ();
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class TagCompound extends AbstractTag implements INamedTagContainer {
 		super (inputStream, anonymous);
 
 		// create map
-		this.tags = new HashMap<> ();
+		this.tags = new HashMap<String, ITag> ();
 
 		// attempt to read all elements
 		do {

--- a/src/main/java/com/evilco/mc/nbt/tag/TagList.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagList.java
@@ -27,7 +27,7 @@ public class TagList extends AbstractTag implements IAnonymousTagContainer {
 	 */
 	public TagList (@Nonnull String name) {
 		super (name);
-		this.tagList = new ArrayList<> ();
+		this.tagList = new ArrayList<ITag> ();
 	}
 
 	/**
@@ -55,7 +55,7 @@ public class TagList extends AbstractTag implements IAnonymousTagContainer {
 		super (inputStream, anonymous);
 
 		// create tagList
-		this.tagList = new ArrayList<> ();
+		this.tagList = new ArrayList<ITag> ();
 
 		// get type ID
 		byte type = inputStream.readByte ();

--- a/src/main/java/com/evilco/mc/nbt/tag/TagType.java
+++ b/src/main/java/com/evilco/mc/nbt/tag/TagType.java
@@ -27,7 +27,7 @@ public enum TagType {
 	 */
 	static {
 		// create map builder
-		ImmutableMap.Builder<Byte, TagType> mapBuilder = new ImmutableMap.Builder<> ();
+		ImmutableMap.Builder<Byte, TagType> mapBuilder = new ImmutableMap.Builder<Byte, TagType> ();
 
 		// add all types
 		for (TagType type : values ()) {


### PR DESCRIPTION
With a slightly edits it can be compiled for running on Java 6.
I think this should have a place because Java 6 is a minimum requirement for Minecraft itself.
